### PR TITLE
Loosen Ruby version requirement to 1.9.2.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ hoespec = Hoe.spec 'linguistics' do
 			"gems of the same name."
 		  ].join( "\n" )
 
-	self.require_ruby_version( '>=1.9.3' )
+	self.require_ruby_version( '>=1.9.2' )
 	self.hg_sign_tags = true if self.respond_to?( :hg_sign_tags= )
 	self.check_history_on_release = true if self.respond_to?( :check_history_on_release= )
 


### PR DESCRIPTION
There is no feature currently used by this gem that is not supported on Ruby 1.9.2. The 1.9.3 requirement precludes testing of gems that require this one in a Ruby 1.9.2 environment. It would be great to relax the Ruby version requirement to 1.9.2.
