### PR TITLE
fix past tense for doubling verbs

### DIFF
--- a/lib/linguistics/en/conjugation.rb
+++ b/lib/linguistics/en/conjugation.rb
@@ -172,7 +172,7 @@ module Linguistics::EN::Conjugation
 			return verb[ 0..-1 ] + 'ied'
 		else
 			if DOUBLING_VERBS.include?( verb )
-				verb = verb[ -2..-1 ] + 'ed'
+				verb = verb + verb[ -1 ] + 'ed'
 			else
 				return verb + 'ed'
 			end

--- a/spec/linguistics/en/conjugation_spec.rb
+++ b/spec/linguistics/en/conjugation_spec.rb
@@ -1633,6 +1633,10 @@ describe Linguistics::EN::Conjugation do
 		"spoonfeed".en.past_tense.should == 'spoonfed'
 	end
 
+	it "conjugates 'spot' as 'spotted'" do
+		"spot".en.past_tense.should == 'spotted'
+	end
+
 	it "conjugates 'spread' as 'spread'" do
 		"spread".en.past_tense.should == 'spread'
 	end


### PR DESCRIPTION
fixes https://bitbucket.org/ged/linguistics/issue/8/wrong-past_tense
