### PR TITLE
fix past tense for words end with y

### DIFF
--- a/lib/linguistics/en/conjugation.rb
+++ b/lib/linguistics/en/conjugation.rb
@@ -169,7 +169,7 @@ module Linguistics::EN::Conjugation
 		when /e$/
 			return verb + 'd'
 		when /[^aeiou]y$/
-			return verb[ 0..-1 ] + 'ied'
+			return verb[ 0..-2 ] + 'ied'
 		else
 			if DOUBLING_VERBS.include?( verb )
 				verb = verb[ -2..-1 ] + 'ed'

--- a/spec/linguistics/en/conjugation_spec.rb
+++ b/spec/linguistics/en/conjugation_spec.rb
@@ -1833,6 +1833,10 @@ describe Linguistics::EN::Conjugation do
 		"troubleshoot".en.past_tense.should == 'troubleshot'
 	end
 
+	it "conjugates 'try' as 'tried'" do
+		"try".en.past_tense.should == 'tried'
+	end
+
 	it "conjugates 'typecast' as 'typecast'" do
 		"typecast".en.past_tense.should == 'typecast'
 	end


### PR DESCRIPTION
fixes https://bitbucket.org/ged/linguistics/issue/10/conjugate-with-past-tense-returns-wrong
