### PR TITLE
"duplicated key" warnings with Ruby 2.2

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -1,0 +1,59 @@
+# -*- encoding: utf-8 -*-
+# stub: linguistics 2.0.2.pre.20150121115142 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "linguistics"
+  s.version = "2.0.2.pre.20150121115142"
+
+  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Michael Granger"]
+  s.date = "2015-01-21"
+  s.description = "Linguistics is a framework for building linguistic utilities for Ruby\nobjects in any language. It includes a generic language-independant\nfront end, a module for mapping language codes into language names, and\na module which contains various English-language utilities."
+  s.email = ["ged@FaerieMUD.org"]
+  s.extra_rdoc_files = ["History.rdoc", "Manifest.txt", "README.rdoc", "History.rdoc", "README.rdoc"]
+  s.files = ["ChangeLog", "History.rdoc", "LICENSE", "Manifest.txt", "README.rdoc", "Rakefile", "examples/endocs.rb", "examples/generalize_sentence.rb", "examples/klingon.rb", "lib/linguistics.rb", "lib/linguistics/en.rb", "lib/linguistics/en/articles.rb", "lib/linguistics/en/conjugation.rb", "lib/linguistics/en/conjunctions.rb", "lib/linguistics/en/infinitives.rb", "lib/linguistics/en/linkparser.rb", "lib/linguistics/en/numbers.rb", "lib/linguistics/en/participles.rb", "lib/linguistics/en/pluralization.rb", "lib/linguistics/en/stemmer.rb", "lib/linguistics/en/titlecase.rb", "lib/linguistics/en/wordnet.rb", "lib/linguistics/inflector.rb", "lib/linguistics/iso639.rb", "lib/linguistics/languagebehavior.rb", "lib/linguistics/monkeypatches.rb", "spec/lib/constants.rb", "spec/lib/helpers.rb", "spec/linguistics/en/articles_spec.rb", "spec/linguistics/en/conjugation_spec.rb", "spec/linguistics/en/conjunctions_spec.rb", "spec/linguistics/en/infinitives_spec.rb", "spec/linguistics/en/linkparser_spec.rb", "spec/linguistics/en/numbers_spec.rb", "spec/linguistics/en/participles_spec.rb", "spec/linguistics/en/pluralization_spec.rb", "spec/linguistics/en/stemmer_spec.rb", "spec/linguistics/en/titlecase_spec.rb", "spec/linguistics/en/wordnet_spec.rb", "spec/linguistics/en_spec.rb", "spec/linguistics/inflector_spec.rb", "spec/linguistics/iso639_spec.rb", "spec/linguistics/monkeypatches_spec.rb", "spec/linguistics_spec.rb"]
+  s.homepage = "http://deveiate.org/code/linguistics"
+  s.licenses = ["BSD"]
+  s.post_install_message = "This library also presents tie-ins for the 'linkparser' and\n'wordnet' libraries, which you can enable by installing the\ngems of the same name."
+  s.rdoc_options = ["-f", "fivefish", "-t", "Ruby Linguistics Toolkit"]
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
+  s.rubygems_version = "2.4.5"
+  s.summary = "Linguistics is a framework for building linguistic utilities for Ruby objects in any language"
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<loggability>, ["~> 0.7"])
+      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_development_dependency(%q<hoe-deveiate>, ["~> 0.3"])
+      s.add_development_dependency(%q<hoe-bundler>, ["~> 1.2"])
+      s.add_development_dependency(%q<linkparser>, ["~> 1.1"])
+      s.add_development_dependency(%q<wordnet>, ["~> 1.0"])
+      s.add_development_dependency(%q<wordnet-defaultdb>, ["~> 1.0"])
+      s.add_development_dependency(%q<ruby-stemmer>, ["~> 0.9"])
+      s.add_development_dependency(%q<hoe>, ["~> 3.13"])
+    else
+      s.add_dependency(%q<loggability>, ["~> 0.7"])
+      s.add_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_dependency(%q<hoe-deveiate>, ["~> 0.3"])
+      s.add_dependency(%q<hoe-bundler>, ["~> 1.2"])
+      s.add_dependency(%q<linkparser>, ["~> 1.1"])
+      s.add_dependency(%q<wordnet>, ["~> 1.0"])
+      s.add_dependency(%q<wordnet-defaultdb>, ["~> 1.0"])
+      s.add_dependency(%q<ruby-stemmer>, ["~> 0.9"])
+      s.add_dependency(%q<hoe>, ["~> 3.13"])
+    end
+  else
+    s.add_dependency(%q<loggability>, ["~> 0.7"])
+    s.add_dependency(%q<rdoc>, ["~> 4.0"])
+    s.add_dependency(%q<hoe-deveiate>, ["~> 0.3"])
+    s.add_dependency(%q<hoe-bundler>, ["~> 1.2"])
+    s.add_dependency(%q<linkparser>, ["~> 1.1"])
+    s.add_dependency(%q<wordnet>, ["~> 1.0"])
+    s.add_dependency(%q<wordnet-defaultdb>, ["~> 1.0"])
+    s.add_dependency(%q<ruby-stemmer>, ["~> 0.9"])
+    s.add_dependency(%q<hoe>, ["~> 3.13"])
+  end
+end

--- a/lib/linguistics/en/pluralization.rb
+++ b/lib/linguistics/en/pluralization.rb
@@ -329,31 +329,30 @@ module Linguistics::EN::Pluralization
 		#	1St pers. sing.		2nd pers. sing.		3rd pers. singular
 		#				3rd pers. (indet.)	
 		"am"	=> "are",	"are"	=> "are",	"is"	 => "are",
-		"was"	=> "were",	"were"	=> "were",	"was"	 => "were",
-		"have"  => "have",	"have"  => "have",	"has"	 => "have",
+		"was"	=> "were",	"were"	=> "were",
+		"have"  => "have",	                  	"has"	 => "have",
 	}
 	PL_v_irregular_pres = matchgroup PL_v_irregular_pres_h.keys
 
 	PL_v_ambiguous_pres_h = {
-		#	1st pers. sing.		2nd pers. sing.		3rd pers. singular
-		#				3rd pers. (indet.)	
-		"act"	=> "act",	"act"	=> "act",	"acts"	  => "act",
-		"blame"	=> "blame",	"blame"	=> "blame",	"blames"  => "blame",
-		"can"	=> "can",	"can"	=> "can",	"can"	  => "can",
-		"must"	=> "must",	"must"	=> "must",	"must"	  => "must",
-		"fly"	=> "fly",	"fly"	=> "fly",	"flies"	  => "fly",
-		"copy"	=> "copy",	"copy"	=> "copy",	"copies"  => "copy",
-		"drink"	=> "drink",	"drink"	=> "drink",	"drinks"  => "drink",
-		"fight"	=> "fight",	"fight"	=> "fight",	"fights"  => "fight",
-		"fire"	=> "fire",	"fire"	=> "fire",	"fires"   => "fire",
-		"like"	=> "like",	"like"	=> "like",	"likes"   => "like",
-		"look"	=> "look",	"look"	=> "look",	"looks"   => "look",
-		"make"	=> "make",	"make"	=> "make",	"makes"   => "make",
-		"reach"	=> "reach",	"reach"	=> "reach",	"reaches" => "reach",
-		"run"	=> "run",	"run"	=> "run",	"runs"    => "run",
-		"sink"	=> "sink",	"sink"	=> "sink",	"sinks"   => "sink",
-		"sleep"	=> "sleep",	"sleep"	=> "sleep",	"sleeps"  => "sleep",
-		"view"	=> "view",	"view"	=> "view",	"views"   => "view",
+		#	1st pers. sing.		3rd pers. singular
+		"act"	=> "act",	"acts"	  => "act",
+		"blame"	=> "blame",	"blames"  => "blame",
+		"can"	=> "can",
+		"must"	=> "must",
+		"fly"	=> "fly",	"flies"	  => "fly",
+		"copy"	=> "copy",	"copies"  => "copy",
+		"drink"	=> "drink",	"drinks"  => "drink",
+		"fight"	=> "fight",	"fights"  => "fight",
+		"fire"	=> "fire",	"fires"   => "fire",
+		"like"	=> "like",	"likes"   => "like",
+		"look"	=> "look",	"looks"   => "look",
+		"make"	=> "make",	"makes"   => "make",
+		"reach"	=> "reach",	"reaches" => "reach",
+		"run"	=> "run",	"runs"    => "run",
+		"sink"	=> "sink",	"sinks"   => "sink",
+		"sleep"	=> "sleep",	"sleeps"  => "sleep",
+		"view"	=> "view",	"views"   => "view",
 	}
 	PL_v_ambiguous_pres = matchgroup PL_v_ambiguous_pres_h.keys
 


### PR DESCRIPTION
Lots of noise with Ruby 2.2:

```
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:332: warning: duplicated key at line 332 ignored: "was"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:333: warning: duplicated key at line 333 ignored: "have"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:340: warning: duplicated key at line 340 ignored: "act"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:341: warning: duplicated key at line 341 ignored: "blame"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:342: warning: duplicated key at line 342 ignored: "can"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:342: warning: duplicated key at line 342 ignored: "can"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:343: warning: duplicated key at line 343 ignored: "must"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:343: warning: duplicated key at line 343 ignored: "must"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:344: warning: duplicated key at line 344 ignored: "fly"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:345: warning: duplicated key at line 345 ignored: "copy"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:346: warning: duplicated key at line 346 ignored: "drink"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:347: warning: duplicated key at line 347 ignored: "fight"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:348: warning: duplicated key at line 348 ignored: "fire"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:349: warning: duplicated key at line 349 ignored: "like"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:350: warning: duplicated key at line 350 ignored: "look"
.../gems/linguistics-2.0.3/lib/linguistics/en/pluralization.rb:351: warning: duplicated key at line 351 ignored: "make"
```

This PR eliminates the duplication.
